### PR TITLE
Add spellfile support

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -7,6 +7,7 @@ Features of this plugin:
 * Specify the languages to be used in spell-check
 * Specify a list of thesauruses for synonym completion
 * Specify a list of dictionaries for word completion
+* Specify a list of spellfiles for custom word-check additions
 * Opt-in key mappings for _Normal_ mode thesaurus and dictionary completion
 * Buffer-scoped configuration (leaves your global settings alone)
 
@@ -101,6 +102,17 @@ let g:lexical#dictionary = ['/usr/share/dict/words',]
 
 You can specify multiple paths to dictionaries in the list.
 
+
+### Spellfile configuration
+On Unix-based systems (including OS X) the spellfile will default to:
+
+```vim
+let g:lexical#dictionary = ['~/.vim/spell/en.utf-8.add',]
+```
+
+You can specify a single path for spellfile in the list.
+
+
 ## Commands
 
 Vim offers many standard key mappings for spell-checking and completion.
@@ -189,6 +201,7 @@ command -nargs=0 LexMed call lexical#init({
                     \ 'thesaurus':  ['~/.vim/dictionary/medical_synonyms.txt',
                     \                '~/.vim/thesaurus/mthesaur.txt',
                     \               ],
+                    \ 'spellfile':  ['~/.vim/spell/en.add'],
                     \ })
 ```
 

--- a/autoload/lexical.vim
+++ b/autoload/lexical.vim
@@ -23,6 +23,9 @@ function! lexical#init(...) abort
   let l:spelllang_list = get(l:args, 'spelllang', g:lexical#spelllang)
   execute 'setlocal spelllang=' . join(l:spelllang_list, ',')
 
+  let l:spellfile_list = get(l:args, 'spellfile', g:lexical#spellfile)
+  execute 'setlocal spellfile=' . join(l:spellfile_list, ',')
+
   let l:thesaurus_list = get(l:args, 'thesaurus', g:lexical#thesaurus)
   execute 'setlocal thesaurus=' . join(l:thesaurus_list, ',')
   if len(&thesaurus) > 0

--- a/plugin/lexical.vim
+++ b/plugin/lexical.vim
@@ -61,6 +61,25 @@ if !exists('g:lexical#dictionary')
   unlet dict_list
 endif
 
+if !exists('g:lexical#spellfile')
+  " build on globally-defined spellfile, if any
+  let spellfile_list = split(&spellfile, ',')
+  if len(spellfile_list) > 0
+    " use the globally-defined spellfile
+    let g:lexical#spellfile = spellfile_list
+  else
+    " attempt to discover a dictionary
+    let spellfile_path = '~/.vim/spell/en.utf-8.add'
+    let g:lexical#spellfile = [
+          \ has('unix') && filereadable(spellfile_path)
+          \ ? spellfile_path
+          \ : ''
+          \ ]
+    unlet spellfile_path
+  endif
+  unlet spellfile_list
+endif
+
 if !exists('g:lexical#spell_key')
   let g:lexical#spell_key = ''
 endif
@@ -69,6 +88,9 @@ if !exists('g:lexical#thesaurus_key')
 endif
 if !exists('g:lexical#dictionary_key')
   let g:lexical#dictionary_key = ''
+endif
+if !exists('g:lexical#spellfile_key')
+  let g:lexical#spellfile_key = ''
 endif
 
 let &cpo = s:save_cpo


### PR DESCRIPTION
Hi Reed,

I finally found the time to add the desired feature: Make it possible to add custom spellfile for each project.

Here is an example how to use it:

``` vim
command -nargs=0 BookEnglisch call lexical#init({
                    \ 'spell': 1,
                    \ 'spelllang':  ['en'],
                    \ 'dictionary': ['/usr/share/dict/words'],
                    \ 'thesaurus':  ['~/.vim/thesaurus/mthesaur.txt'],
                    \ 'spellfile':  ['~/.vim/spell/en.utf-8.add'],
                    \ })

command -nargs=0 BookGerman call lexical#init({
                    \ 'spell': 1,
                    \ 'spelllang':  ['de_20'],
                    \ 'dictionary': ['~/.vim/spell/gerspchk.dict'],
                    \ 'thesaurus':  ['~/.vim/thesaurus/openthesaurus.txt'],
                    \ 'spellfile':  ['~/.vim/spell/de.utf-8.add'],
                    \ })
```

Hope everything is ready for a merge.

Bests

Matthias
