### PR TITLE
Fix spellfile <-> dictionary typo

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -107,7 +107,7 @@ You can specify multiple paths to dictionaries in the list.
 On Unix-based systems (including OS X) the spellfile will default to:
 
 ```vim
-let g:lexical#dictionary = ['~/.vim/spell/en.utf-8.add',]
+let g:lexical#spellfile = ['~/.vim/spell/en.utf-8.add',]
 ```
 
 You can specify a single path for spellfile in the list.

--- a/plugin/lexical.vim
+++ b/plugin/lexical.vim
@@ -68,7 +68,7 @@ if !exists('g:lexical#spellfile')
     " use the globally-defined spellfile
     let g:lexical#spellfile = spellfile_list
   else
-    " attempt to discover a dictionary
+    " attempt to discover a spellfile
     let spellfile_path = '~/.vim/spell/en.utf-8.add'
     let g:lexical#spellfile = [
           \ has('unix') && filereadable(spellfile_path)


### PR DESCRIPTION
There are some (small) typo in spellfile referring to dictionary instead.

I've fixed them.
